### PR TITLE
Update Docs for MapLibre Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "maplibre-gl-native",
+    name: "MapLibre GL Native",
     products: [
         .library(
             name: "Mapbox",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
-# MapBox GL Native SDK Open-Source Fork
+# MapLibre GL Native SDK for iOS
 
-For iOS and Android 
+![Requires Xcode 12](https://img.shields.io/badge/Xcode-12-1575F9.svg?style=flat&logo=xcode&logoColor=1575F9)
+[![Requires Swift 5.3](https://img.shields.io/badge/Swift-5.3-FA7343.svg?style=flat&logo=Swift)](https://swift.org/package-manager/)
+![SPM compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-FA7343.svg?style=flat&logo=Swift)
 
-MapLibre GL Native is a community led fork derived from [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) prior to their switch to a non-OSS license. The fork also includes Maps SDK for iOS and MacOS (forked from [mapbox-gl-native-ios](https://github.com/mapbox/mapbox-gl-native-ios)) and Android SDK (forked from [mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)).
+[MapLibre GL Native](https://github.com/maptiler/maplibre-gl-native) is a community led fork derived from [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native) prior to their switch to a non-OSS license. The fork also includes Maps SDK for iOS and macOS (forked from [mapbox-gl-native-ios](https://github.com/mapbox/mapbox-gl-native-ios)) and Android SDK (forked from [mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)).
+
+---
+
+## Add MapLibre to your Project
+
+To add a package dependency to your Xcode project, select File > Swift Packages > Add Package Dependency and enter its repository URL. See [Adding Package Dependencies to Your App.](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app)
+
+## Swift Packages Development
+
+You can override the MapLibre package dependency and edit its content by adding it as a local package.  See [Editing a Package Dependency as a Local Package](https://developer.apple.com/documentation/swift_packages/editing_a_package_dependency_as_a_local_package).
+
+You can add this to `Package.swift`
+
+```swift
+.binaryTarget(
+  name: "Mapbox",
+  path: "build/output/Mapbox.xcframework"),
+```
+
+Other References from developer.apple.com
+
+* Find out if a package dependency references a binary and verify the binary’s authenticity.  See [Identifying Binary Dependencies.](https://developer.apple.com/documentation/swift_packages/identifying_binary_dependencies)


### PR DESCRIPTION
1. Change public SPM name to "MapLibre GL Native"
2. Update Docs to add Shields for supported Xcode & Swift
3. Update Docs for developers wishing to update `Mapbox.xcframework`

---

Result of Docs change: *# 2. Update Docs to add Shields for supported Xcode & Swift*

* Testing shows that this Swift Package only works with Xcode 12 which uses Swift 5.3

<img width="436" alt="pr1-update-distribution-docs" src="https://user-images.githubusercontent.com/118112/105920684-a8921a80-5fec-11eb-9dca-9929ca5ca00e.png">


---

Result of Docs change:  *# 1. Change public SPM name to "MapLibre GL Native"* 

![rename-MapLibre_GL_Native](https://user-images.githubusercontent.com/118112/105920411-31f51d00-5fec-11eb-86ec-ab3a234ee7f8.png)

---

Result of how MapLibre `5.10.0` is revealed in Xcode

<img width="295" alt="maplibre-spm-5 9 0" src="https://user-images.githubusercontent.com/118112/105923688-923a8d80-5ff1-11eb-8204-ea6cb97ca6e3.png">
