### PR TITLE
Test MapLibre with a Swift Playgrounds

### DIFF
--- a/MapLibreTest.playground/Contents.swift
+++ b/MapLibreTest.playground/Contents.swift
@@ -1,0 +1,29 @@
+/*:
+ * The MapLibre Test Playground demonstrates basic rendering of a Mapbox style using the current MapLibre binary.
+ * Useful for testing the data in the`binaryTarget[]` in this Swift Package repo.
+ * Downloads the MapLibre `.xcframework` and creates a simple map, thereby testing the Swift Package Manager workflow.
+ * Add your style for basic rendering tests
+ */
+
+import UIKit
+import PlaygroundSupport
+import Mapbox
+
+// Create a map set its dimensions
+let width: CGFloat = 600
+let height: CGFloat = 400
+
+let mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
+mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
+
+// Hide logo & attribution button
+mapView.logoView.isHidden = true
+mapView.attributionButton.isHidden = true
+
+PlaygroundPage.current.liveView = mapView
+
+// Set Style
+let styleJSON = "https://raw.githubusercontent.com/roblabs/openmaptiles-ios-demo/master/OSM2VectorTiles/styles/geography-class.GitHub.json"
+
+mapView.styleURL = URL(string: styleJSON)
+mapView.setCenter(CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), zoomLevel: 2, animated: false)

--- a/MapLibreTest.playground/Contents.swift
+++ b/MapLibreTest.playground/Contents.swift
@@ -20,10 +20,18 @@ mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
 mapView.logoView.isHidden = true
 mapView.attributionButton.isHidden = true
 
-PlaygroundPage.current.liveView = mapView
+// enable debugging tile features
+mapView.debugMask = MGLMapDebugMaskOptions(rawValue:
+                                            // Edges of tile boundaries
+                                            MGLMapDebugMaskOptions.tileBoundariesMask.rawValue +
+                                            // tile coordinate (x/y/z)
+                                            MGLMapDebugMaskOptions.tileInfoMask.rawValue
+                                          )
 
 // Set Style
 let styleJSON = "https://raw.githubusercontent.com/roblabs/openmaptiles-ios-demo/master/OSM2VectorTiles/styles/geography-class.GitHub.json"
 
 mapView.styleURL = URL(string: styleJSON)
 mapView.setCenter(CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), zoomLevel: 2, animated: false)
+
+PlaygroundPage.current.liveView = mapView

--- a/MapLibreTest.playground/contents.xcplayground
+++ b/MapLibreTest.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' display-mode='raw' buildActiveScheme='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/MapLibreTest.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/MapLibreTest.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MapLibreTest.playground/timeline.xctimeline
+++ b/MapLibreTest.playground/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/README.md
+++ b/README.md
@@ -16,17 +16,26 @@ To add a package dependency to your Xcode project, select File > Swift Packages 
 
 You can override the MapLibre package dependency and edit its content by adding it as a local package.  See [Editing a Package Dependency as a Local Package](https://developer.apple.com/documentation/swift_packages/editing_a_package_dependency_as_a_local_package).
 
-You can add this to `Package.swift`
+For example, you can add this to `Package.swift`, if you are interested in testing the Mapbox framework with another framework.
 
 ```swift
-.binaryTarget(
-  name: "Mapbox",
-  path: "build/output/Mapbox.xcframework"),
+products: [
+    .library( name: "Mapbox", targets: ["Mapbox"]),
+    .library( name: "MetalANGLE", targets: ["MetalANGLE"])
+],
+dependencies: [ ],
+// target path should be relative to package root
+targets: [
+    .binaryTarget(name: "Mapbox", path: "Mapbox.xcframework"),
+    .binaryTarget(name: "MetalANGLE", path: "MetalANGLE.xcframework")
+]
 ```
 
 Other References from developer.apple.com
 
 * Find out if a package dependency references a binary and verify the binary’s authenticity.  See [Identifying Binary Dependencies.](https://developer.apple.com/documentation/swift_packages/identifying_binary_dependencies)
+
+* WWDC20 [Distribute binary frameworks as Swift packages](https://developer.apple.com/wwdc20/10147), which describes several features of a binary targets.
 
 ## Test MapLibre with a Swift Playgrounds
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ You can add this to `Package.swift`
 Other References from developer.apple.com
 
 * Find out if a package dependency references a binary and verify the binary’s authenticity.  See [Identifying Binary Dependencies.](https://developer.apple.com/documentation/swift_packages/identifying_binary_dependencies)
+
+## Test MapLibre with a Swift Playgrounds
+
+When you download this repo there is a Swift Playground that allows you to change the style and play around with a very simple rendered map.  
+
+* Download this repo
+* Navigate to the folder where you `clone`d, and open `Package.swift` in at least Xcode 12.
+* Run Playground by choosing `Editor` > `Run Playground` or `⇧⌘⏎`


### PR DESCRIPTION
 * The MapLibre Test Playground demonstrates basic rendering of a Mapbox style using the current MapLibre binary.
 * Useful for testing the data in the`binaryTarget[]` in this Swift Package repo.
 * Downloads the MapLibre `.xcframework` and creates a simple map, thereby testing the Swift Package Manager workflow.
 * Add your style for basic rendering tests

*Example of MapLibreTest.playground*
![image](https://user-images.githubusercontent.com/118112/112228469-9698b680-8bee-11eb-8b50-3cc8ec01b7a1.png)
