### PR TITLE
Update Swift Playground to use `import MapLibre`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.swiftpm
+/.build

--- a/MapLibreTest.playground/Contents.swift
+++ b/MapLibreTest.playground/Contents.swift
@@ -17,6 +17,9 @@ let height: CGFloat = 480
 let mapView = MLNMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
 mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
+// shows the result of running the code this far
+PlaygroundPage.current.liveView = mapView
+
 // Hide logo & attribution button
 mapView.logoView.isHidden = true
 mapView.attributionButton.isHidden = true
@@ -43,12 +46,12 @@ let options = MLNMapSnapshotOptions(styleURL: URL(string: styleJSON), camera: ca
 options.zoomLevel = mapView.zoomLevel
 
 let snapshotter = MLNMapSnapshotter(options: options)
-snapshotter.start { (snapshot, error) in
-    if let error = error {
-        fatalError(error.localizedDescription)
-    }
-    
-    image = snapshot?.image
-}
+// Awaiting https://github.com/maplibre/maplibre-native/issues/1979
+//snapshotter.start { (snapshot, error) in
+//    if let error = error {
+//        fatalError(error.localizedDescription)
+//    }
+//    
+//    image = snapshot?.image
+//}
 
-PlaygroundPage.current.liveView = mapView

--- a/MapLibreTest.playground/Contents.swift
+++ b/MapLibreTest.playground/Contents.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 import PlaygroundSupport
-import Mapbox
+import MapLibre
 
 // Create a map set its dimensions
 let width: CGFloat = 640
 let height: CGFloat = 480
 
-let mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
+let mapView = MLNMapView(frame: CGRect(x: 0, y: 0, width: width, height: height))
 mapView.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
 // Hide logo & attribution button
@@ -22,11 +22,11 @@ mapView.logoView.isHidden = true
 mapView.attributionButton.isHidden = true
 
 // enable debugging tile features
-mapView.debugMask = MGLMapDebugMaskOptions(rawValue:
-                                            MGLMapDebugMaskOptions.collisionBoxesMask.rawValue + // Edges of glyphs and symbols
-                                            MGLMapDebugMaskOptions.timestampsMask.rawValue     + // shows a timestamp indicating when it was loaded.
-                                            MGLMapDebugMaskOptions.tileBoundariesMask.rawValue + // Edges of tile boundaries
-                                            MGLMapDebugMaskOptions.tileInfoMask.rawValue         // tile coordinate (x/y/z)
+mapView.debugMask = MLNMapDebugMaskOptions(rawValue:
+                                            MLNMapDebugMaskOptions.collisionBoxesMask.rawValue + // Edges of glyphs and symbols
+                                            MLNMapDebugMaskOptions.timestampsMask.rawValue     + // shows a timestamp indicating when it was loaded.
+                                            MLNMapDebugMaskOptions.tileBoundariesMask.rawValue + // Edges of tile boundaries
+                                            MLNMapDebugMaskOptions.tileInfoMask.rawValue         // tile coordinate (x/y/z)
                                           )
 
 // Set Style
@@ -37,12 +37,12 @@ mapView.setCenter(CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), zoomLev
 
 // MGLMapSnapshotter example code
 var image: UIImage?
-let camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 0, longitude: 0), altitude: 100, pitch: 75, heading: 45)
+let camera = MLNMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 0, longitude: 0), altitude: 100, pitch: 75, heading: 45)
 
-let options = MGLMapSnapshotOptions(styleURL: URL(string: styleJSON), camera: camera, size: CGSize(width: width, height: height))
+let options = MLNMapSnapshotOptions(styleURL: URL(string: styleJSON), camera: camera, size: CGSize(width: width, height: height))
 options.zoomLevel = mapView.zoomLevel
 
-let snapshotter = MGLMapSnapshotter(options: options)
+let snapshotter = MLNMapSnapshotter(options: options)
 snapshotter.start { (snapshot, error) in
     if let error = error {
         fatalError(error.localizedDescription)

--- a/MapLibreTest.playground/timeline.xctimeline
+++ b/MapLibreTest.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>


### PR DESCRIPTION
This PR includes updates to the Swift Playground for [MapLibre 6.0.0](https://github.com/maplibre/maplibre-gl-native-distribution/releases/tag/6.0.0).  The Playground is distributed as part of the Swift Package and gives a simple demo of MapLibre as it would run in an iOS Simulator.

Examples below are a couple of quickly prototyped MapLibre styles running in the Playground.

#### Details

* Swift Playground changes for https://github.com/maplibre/maplibre-native/pull/919

* Awaiting
  * https://github.com/maplibre/maplibre-native/issues/1862
  * https://github.com/maplibre/maplibre-native/issues/1979

---

*[MapLibre Demo Style](https://github.com/maplibre/demotiles#maplibre-demo-tiles) with logo & attribution*

![image](https://github.com/maplibre/maplibre-gl-native-distribution/assets/118112/2bd062fb-9062-4ae9-835a-0eedd61771c4)

---

*[OSM Americana](https://github.com/zelonewolf/openstreetmap-americana) Demo Style with `collisionBoxesMask`, `tileBoundariesMask`, & `tileInfoMask`.*

![image](https://github.com/maplibre/maplibre-gl-native-distribution/assets/118112/605b3adf-1f3d-4c85-9bc7-925eca8b89dc)

---

*[Terrain](https://github.com/maplibre/demotiles/tree/gh-pages/terrain-tiles#terrain-tiles), centered around Innsbruck, Austria*
![image](https://github.com/maplibre/maplibre-gl-native-distribution/assets/118112/c9f4880d-9a82-4a30-be2b-943f76639ba0)
